### PR TITLE
Fix missing reasons, wrong codes in error messages

### DIFF
--- a/xorg-choose-window.c
+++ b/xorg-choose-window.c
@@ -226,7 +226,7 @@ int max (int a, int b) {
  * Print an error message to stderr and exit the process with the given status.
  *
  * code: exit code
- * fmt, ...: arguments as taken by `*printf`
+ * fmt, va_list: arguments as taken by `vprintf`
  */
 void xcw_vfail (int code, char *fmt, va_list args) {
     fprintf(stderr, "error: ");

--- a/xorg-choose-window.c
+++ b/xorg-choose-window.c
@@ -228,13 +228,25 @@ int max (int a, int b) {
  * code: exit code
  * fmt, ...: arguments as taken by `*printf`
  */
-void xcw_fail (int code, char *fmt, ...) {
-    va_list args;
+void xcw_vfail (int code, char *fmt, va_list args) {
     fprintf(stderr, "error: ");
-    va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     va_end(args);
     exit(code);
+}
+
+
+/**
+ * Print an error message to stderr and exit the process with the given status.
+ *
+ * code: exit code
+ * fmt, ...: arguments as taken by `*printf`
+ */
+void xcw_fail (int code, char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    xcw_vfail(code, fmt, args);
+    /* xcw_vfail will call va_end and exit */
 }
 
 
@@ -246,8 +258,8 @@ void xcw_fail (int code, char *fmt, ...) {
 void xcw_die (char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    xcw_fail(EX_SOFTWARE, fmt, args);
-    va_end(args);
+    xcw_vfail(EX_SOFTWARE, fmt, args);
+    /* xcw_vfail will call va_end and exit */
 }
 
 


### PR DESCRIPTION
Passing a va_list to a function which takes variadic arguments is not
valid; xcw_die was doing this with xcw_fail which was causing xcw_fail
to print garbage instead of proper reasons and error codes. On my system
the output did tend to look plausible, hence why this probably went
unnoticed for so long.

Added a function xcw_vfail which takes a va_list so that xcw_die may
call it correctly.