### PR TITLE
Fix class name not being set

### DIFF
--- a/xorg-choose-window.c
+++ b/xorg-choose-window.c
@@ -140,7 +140,7 @@ int BG_COLOUR = 0xff333333;
 /**
  * Window class set on overlay windows.
  */
-char* OVERLAY_WINDOW_CLASS = "overlay\0xorg-choose-window";
+#define OVERLAY_WINDOW_CLASS "overlay\0xorg-choose-window"
 /**
  * Number of windows requested from _NET_CLIENT_LIST.
  */


### PR DESCRIPTION
When OVERLAY_WINDOW_CLASS was a char*, sizeof() would return 8, not the
length of the string. By pure coincidence this happens to be the length
of the word "overlay" so at least the instance class appeared to be set
correctly.

Changed it to a static string so sizeof returns the correct length.