### PR TITLE
Add style options

### DIFF
--- a/xorg-choose-window.c
+++ b/xorg-choose-window.c
@@ -38,7 +38,6 @@ specific language governing permissions and limitations under the License.
 
 // TODO (improvements)
 // larger default font
-// configurable font/text size/colours
 // manpage
 //  - mention in readme
 //  - move exit status info from --help

--- a/xorg-choose-window.c
+++ b/xorg-choose-window.c
@@ -1169,11 +1169,10 @@ xcb_window_t* overlay_create (xcw_state_t* state, int x, int y, int w, int h) {
     // for alpha channel we need to create a window with depth 32, which
     // requires supplying a non-default colormap
     int depth = 32;
+    xcb_visualid_t visualid;
     xcb_colormap_t win_colormap;
     win_colormap = xcb_generate_id(state->xcon);
-    xcb_visualid_t visualid;
-    visualid = get_visualid_by_depth(state->xscreen, depth);
-    if (visualid != 0) {
+    if ((visualid = get_visualid_by_depth(state->xscreen, depth))) {
         xcb_create_colormap(state->xcon, XCB_COLORMAP_ALLOC_NONE, win_colormap,
             state->xroot, visualid);
     }
@@ -1181,8 +1180,7 @@ xcb_window_t* overlay_create (xcw_state_t* state, int x, int y, int w, int h) {
     else {
         depth = XCB_COPY_FROM_PARENT;
         visualid = XCB_COPY_FROM_PARENT;
-        win_colormap = state->xscreen->default_colormap;
-        mask ^= XCB_CW_COLORMAP;
+        win_colormap = XCB_COPY_FROM_PARENT;
     }
     uint32_t values[] = {
         state->input->bg_colour, state->xscreen->black_pixel, 1,


### PR DESCRIPTION
### Proposals for the present
This PR adds the following style options:

```
       --bg-colour=COLOUR     Background colour. Colours are given in
                              hexadecimal in the form [#]RRGGBB[AA]
       --fg-colour=COLOUR     Foreground colour. Colours are given in
                              hexadecimal in the form [#]RRGGBB[AA]
   -t, --font=FONT            Font specified as a core X11 font name (xlsfonts
                              can help find valid names)
   -p, --position=[X[%]]x[Y[%]]   Offset position of overlay window by X pixels
                              horizontally and Y pixels vertically, unless % is
                              given, indicating the value is to be taken as a
                              percentage of the target window's size
   -s, --size=[WIDTH[%]]x[HEIGHT[%]]
                              Set width and height of the overlay window in
                              pixels, unless % is given, indicating the value is
                              to be taken as a percentage of the target window's
                              size
   -h, --anchor-h=LEFT|CENTER|RIGHT
                              Anchor overlay window horizontally (CENTER by
                              default)
   -v, --anchor-v=TOP|CENTER|BOTTOM
                              Anchor overlay window vertically (CENTER by
                              default)
```

Here is an example showing the style options being put through their paces (you may need to remove the font option or pick a different one if you don't have dejavu sans, `xlsfonts` can help with that):

`xorg-choose-window sdfjkl -h LEFT -v BOTTOM --size=50x50 --fg-colour=fab1ed --bg-colour=ca5cade5 --font='-misc-dejavu sans-medium-r-normal--25-0-0-0-p-0-ascii-0'`

It looks like this on my computer:

![screenshot showing three terminal windows with sizable pink easy-motion letter hints in their bottom left corners. There is also an ascii cat named herman in one of the terminals](https://user-images.githubusercontent.com/11167504/216461947-35d30296-923e-4edf-833e-0ba93bb0f0b4.png)

Fixes: https://github.com/ikn/xorg-choose-window/issues/4

### Ideas for the future
* Keep hints on screen even if they would be placed off screen
* Add freetype/fontconfig support, for anti-aliased font rendering